### PR TITLE
Fix: Prometheus Certificate Validity (UTC) issue

### DIFF
--- a/configs/service-overrides/prometheus/prometheus-override.yml
+++ b/configs/service-overrides/prometheus/prometheus-override.yml
@@ -15,9 +15,9 @@ prometheusOperator:
     certManager:
       enabled: true
       rootCert:
-        duration: "26280h"
+        duration: "8750"
       admissionCert:
-        duration: "26280h"
+        duration: "8750"
       issuerRef:
         name: "edge-conductor-ca"
         kind: "ClusterIssuer"


### PR DESCRIPTION
Update the validity period to less than 1 year.

https://jira.devtools.intel.com/browse/EPJ-3201

Signed-off-by: Shan,junjun <junjun.shan@intel.com>